### PR TITLE
feat: Add OWNER role with user management and fix programs translations

### DIFF
--- a/backend/src/main/java/com/example/proxy/config/DataInitializer.java
+++ b/backend/src/main/java/com/example/proxy/config/DataInitializer.java
@@ -38,6 +38,25 @@ public class DataInitializer {
                                    VolunteerApplicationRepository volunteerRepository,
                                    PaymentTransactionRepository paymentRepository) {
         return args -> {
+            // Create owner user if not exists
+            if (!userRepository.existsByUsername("owner")) {
+                User owner = new User();
+                owner.setUsername("owner");
+                owner.setEmail("owner@desn.org.np");
+                owner.setPassword(passwordEncoder.encode("owner123"));
+                owner.setFullName("DESN Owner");
+                owner.setRole(User.Role.OWNER);
+                owner.setEnabled(true);
+                
+                userRepository.save(owner);
+                logger.info("✅ Default owner user created successfully!");
+                logger.info("   Username: owner");
+                logger.info("   Password: owner123");
+                logger.info("   ⚠️  IMPORTANT: Change this password in production!");
+            } else {
+                logger.info("Owner user already exists. Skipping initialization.");
+            }
+            
             // Check if admin user already exists
             if (!userRepository.existsByUsername("admin")) {
                 User admin = new User();

--- a/backend/src/main/java/com/example/proxy/controller/UserController.java
+++ b/backend/src/main/java/com/example/proxy/controller/UserController.java
@@ -1,0 +1,254 @@
+package com.example.proxy.controller;
+
+import com.example.proxy.entity.User;
+import com.example.proxy.repository.UserRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/users")
+@CrossOrigin(origins = "*")
+public class UserController {
+
+    private static final Logger log = LoggerFactory.getLogger(UserController.class);
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public UserController(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    /**
+     * Get all users - OWNER only
+     */
+    @GetMapping
+    @PreAuthorize("hasRole('OWNER')")
+    public ResponseEntity<?> getAllUsers() {
+        try {
+            List<User> users = userRepository.findAll();
+            List<Map<String, Object>> userList = users.stream()
+                .map(user -> {
+                    Map<String, Object> userMap = new HashMap<>();
+                    userMap.put("id", user.getId());
+                    userMap.put("username", user.getUsername());
+                    userMap.put("email", user.getEmail());
+                    userMap.put("fullName", user.getFullName());
+                    userMap.put("role", user.getRole().name());
+                    userMap.put("enabled", user.isEnabled());
+                    userMap.put("createdAt", user.getCreatedAt());
+                    return userMap;
+                })
+                .collect(Collectors.toList());
+
+            return ResponseEntity.ok(userList);
+        } catch (Exception e) {
+            log.error("Error fetching users", e);
+            return ResponseEntity.internalServerError()
+                .body(Map.of("error", "Failed to fetch users"));
+        }
+    }
+
+    /**
+     * Update user role - OWNER only
+     */
+    @PutMapping("/{id}/role")
+    @PreAuthorize("hasRole('OWNER')")
+    public ResponseEntity<?> updateUserRole(@PathVariable Long id, @RequestBody Map<String, String> request) {
+        try {
+            String newRole = request.get("role");
+            
+            if (newRole == null || (!newRole.equals("OWNER") && !newRole.equals("ADMIN") && !newRole.equals("MEMBER"))) {
+                return ResponseEntity.badRequest()
+                    .body(Map.of("error", "Invalid role. Must be OWNER, ADMIN, or MEMBER"));
+            }
+
+            User user = userRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+            user.setRole(User.Role.valueOf(newRole));
+            userRepository.save(user);
+
+            log.info("User {} role updated to {}", user.getUsername(), newRole);
+
+            return ResponseEntity.ok(Map.of(
+                "success", true,
+                "message", "User role updated successfully",
+                "user", Map.of(
+                    "id", user.getId(),
+                    "username", user.getUsername(),
+                    "email", user.getEmail(),
+                    "fullName", user.getFullName(),
+                    "role", user.getRole().name(),
+                    "enabled", user.isEnabled()
+                )
+            ));
+        } catch (Exception e) {
+            log.error("Error updating user role", e);
+            return ResponseEntity.internalServerError()
+                .body(Map.of("error", "Failed to update user role: " + e.getMessage()));
+        }
+    }
+
+    /**
+     * Delete user - OWNER only
+     */
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('OWNER')")
+    public ResponseEntity<?> deleteUser(@PathVariable Long id) {
+        try {
+            User user = userRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+            // Prevent deleting the last owner
+            if (user.getRole() == User.Role.OWNER) {
+                long ownerCount = userRepository.findAll().stream()
+                    .filter(u -> u.getRole() == User.Role.OWNER)
+                    .count();
+                
+                if (ownerCount <= 1) {
+                    return ResponseEntity.badRequest()
+                        .body(Map.of("error", "Cannot delete the last owner"));
+                }
+            }
+
+            String username = user.getUsername();
+            userRepository.delete(user);
+
+            log.info("User {} deleted", username);
+
+            return ResponseEntity.ok(Map.of(
+                "success", true,
+                "message", "User deleted successfully"
+            ));
+        } catch (Exception e) {
+            log.error("Error deleting user", e);
+            return ResponseEntity.internalServerError()
+                .body(Map.of("error", "Failed to delete user: " + e.getMessage()));
+        }
+    }
+
+    /**
+     * Create new user - OWNER only
+     */
+    @PostMapping
+    @PreAuthorize("hasRole('OWNER')")
+    public ResponseEntity<?> createUser(@RequestBody Map<String, String> request) {
+        try {
+            String username = request.get("username");
+            String email = request.get("email");
+            String password = request.get("password");
+            String fullName = request.get("fullName");
+            String role = request.get("role");
+
+            // Validation
+            if (username == null || username.trim().isEmpty()) {
+                return ResponseEntity.badRequest()
+                    .body(Map.of("error", "Username is required"));
+            }
+            if (email == null || email.trim().isEmpty()) {
+                return ResponseEntity.badRequest()
+                    .body(Map.of("error", "Email is required"));
+            }
+            if (password == null || password.trim().isEmpty()) {
+                return ResponseEntity.badRequest()
+                    .body(Map.of("error", "Password is required"));
+            }
+            if (role == null || (!role.equals("OWNER") && !role.equals("ADMIN") && !role.equals("MEMBER"))) {
+                return ResponseEntity.badRequest()
+                    .body(Map.of("error", "Invalid role. Must be OWNER, ADMIN, or MEMBER"));
+            }
+
+            // Check if username exists
+            if (userRepository.existsByUsername(username)) {
+                return ResponseEntity.badRequest()
+                    .body(Map.of("error", "Username already exists"));
+            }
+
+            // Check if email exists
+            if (userRepository.existsByEmail(email)) {
+                return ResponseEntity.badRequest()
+                    .body(Map.of("error", "Email already exists"));
+            }
+
+            // Create new user
+            User user = new User();
+            user.setUsername(username);
+            user.setEmail(email);
+            user.setPassword(passwordEncoder.encode(password));
+            user.setFullName(fullName != null ? fullName : username);
+            user.setRole(User.Role.valueOf(role));
+            user.setEnabled(true);
+
+            user = userRepository.save(user);
+
+            log.info("New user created by owner: {} with role {}", user.getUsername(), user.getRole());
+
+            return ResponseEntity.ok(Map.of(
+                "success", true,
+                "message", "User created successfully",
+                "user", Map.of(
+                    "id", user.getId(),
+                    "username", user.getUsername(),
+                    "email", user.getEmail(),
+                    "fullName", user.getFullName(),
+                    "role", user.getRole().name(),
+                    "enabled", user.isEnabled()
+                )
+            ));
+        } catch (Exception e) {
+            log.error("Error creating user", e);
+            return ResponseEntity.internalServerError()
+                .body(Map.of("error", "Failed to create user: " + e.getMessage()));
+        }
+    }
+
+    /**
+     * Toggle user enabled status - OWNER only
+     */
+    @PutMapping("/{id}/toggle-status")
+    @PreAuthorize("hasRole('OWNER')")
+    public ResponseEntity<?> toggleUserStatus(@PathVariable Long id) {
+        try {
+            User user = userRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+            // Prevent disabling the last owner
+            if (user.getRole() == User.Role.OWNER && user.isEnabled()) {
+                long enabledOwnerCount = userRepository.findAll().stream()
+                    .filter(u -> u.getRole() == User.Role.OWNER && u.isEnabled())
+                    .count();
+                
+                if (enabledOwnerCount <= 1) {
+                    return ResponseEntity.badRequest()
+                        .body(Map.of("error", "Cannot disable the last enabled owner"));
+                }
+            }
+
+            user.setEnabled(!user.isEnabled());
+            userRepository.save(user);
+
+            log.info("User {} status toggled to {}", user.getUsername(), user.isEnabled() ? "enabled" : "disabled");
+
+            return ResponseEntity.ok(Map.of(
+                "success", true,
+                "message", "User status updated successfully",
+                "enabled", user.isEnabled()
+            ));
+        } catch (Exception e) {
+            log.error("Error toggling user status", e);
+            return ResponseEntity.internalServerError()
+                .body(Map.of("error", "Failed to update user status: " + e.getMessage()));
+        }
+    }
+}

--- a/backend/src/main/java/com/example/proxy/entity/User.java
+++ b/backend/src/main/java/com/example/proxy/entity/User.java
@@ -46,6 +46,7 @@ public class User implements UserDetails {
     private LocalDateTime updatedAt;
 
     public enum Role {
+        OWNER,
         ADMIN,
         MEMBER
     }

--- a/backend/src/main/java/com/example/proxy/service/AuthService.java
+++ b/backend/src/main/java/com/example/proxy/service/AuthService.java
@@ -64,13 +64,9 @@ public class AuthService implements UserDetailsService {
         user.setPassword(passwordEncoder.encode(request.getPassword()));
         user.setFullName(request.getFullName());
         
-        // Set role (default to MEMBER, only allow ADMIN via environment/config)
-        try {
-            user.setRole(User.Role.valueOf(request.getRole().toUpperCase()));
-        } catch (IllegalArgumentException e) {
-            user.setRole(User.Role.MEMBER);
-        }
-        
+        // Always set new registrations to MEMBER role
+        // Only OWNER can change roles to ADMIN or OWNER
+        user.setRole(User.Role.MEMBER);
         user.setEnabled(true);
 
         user = userRepository.save(user);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ const Login = lazy(() => import("./views/Login"));
 const Register = lazy(() => import("./views/Register"));
 const AdminDashboard = lazy(() => import("./views/AdminDashboard"));
 const MemberDashboard = lazy(() => import("./views/MemberDashboard"));
+const OwnerDashboard = lazy(() => import("./views/OwnerDashboard"));
 const PaymentVerify = lazy(() => import("./views/PaymentVerify"));
 const AccessibilityStatement = lazy(
   () => import("./views/AccessibilityStatement")
@@ -60,6 +61,7 @@ export default function App() {
                   />
                   <Route path='/login' element={<Login />} />
                   <Route path='/register' element={<Register />} />
+                  <Route path='/owner/dashboard' element={<OwnerDashboard />} />
                   <Route path='/admin/dashboard' element={<AdminDashboard />} />
                   <Route
                     path='/member/dashboard'

--- a/src/components/programs/CorePrograms.tsx
+++ b/src/components/programs/CorePrograms.tsx
@@ -313,10 +313,10 @@ export default function CorePrograms() {
       <Container maxWidth='xl'>
         <SectionHeader>
           <SectionTitle id='core-programs-title'>
-            {t("programs:core.title")}
+            {t("programs.core.title")}
           </SectionTitle>
           <SectionDescription>
-            {t("programs:core.description")}
+            {t("programs.core.description")}
           </SectionDescription>
         </SectionHeader>
 
@@ -326,7 +326,7 @@ export default function CorePrograms() {
             <Box position='relative'>
               <ProgramImage
                 src={program1}
-                alt={t("programs:core.program1.image_alt")}
+                alt={t("programs.core.program1.image_alt")}
               />
               <IconBadge
                 bgcolor='rgba(0, 76, 145, 0.1)'
@@ -338,35 +338,35 @@ export default function CorePrograms() {
             <ProgramContent>
               <div>
                 <Badge bgcolor='rgba(0, 76, 145, 0.1)'>
-                  <BadgeText>{t("programs:core.program1.badge")}</BadgeText>
+                  <BadgeText>{t("programs.core.program1.badge")}</BadgeText>
                 </Badge>
-                <ProgramTitle>{t("programs:core.program1.title")}</ProgramTitle>
+                <ProgramTitle>{t("programs.core.program1.title")}</ProgramTitle>
                 <ProgramDescription>
-                  {t("programs:core.program1.description")}
+                  {t("programs.core.program1.description")}
                 </ProgramDescription>
                 <StatsContainer>
                   <StatItem>
                     <StatNumber>5000+</StatNumber>
-                    <StatLabel>{t("programs:core.beneficiaries")}</StatLabel>
+                    <StatLabel>{t("programs.core.beneficiaries")}</StatLabel>
                   </StatItem>
                   <StatItem>
                     <StatNumber>25</StatNumber>
-                    <StatLabel>{t("programs:core.projects")}</StatLabel>
+                    <StatLabel>{t("programs.core.projects")}</StatLabel>
                   </StatItem>
                   <StatItem>
                     <StatNumber>High</StatNumber>
-                    <StatLabel>{t("programs:core.impact")}</StatLabel>
+                    <StatLabel>{t("programs.core.impact")}</StatLabel>
                   </StatItem>
                 </StatsContainer>
-                <FeaturesTitle>{t("programs:core.key_features")}</FeaturesTitle>
+                <FeaturesTitle>{t("programs.core.key_features")}</FeaturesTitle>
                 <FeaturesList>
                   {Array.isArray(
-                    t("programs:core.program1.features", {
+                    t("programs.core.program1.features", {
                       returnObjects: true,
                     })
                   ) &&
                     (
-                      t("programs:core.program1.features", {
+                      t("programs.core.program1.features", {
                         returnObjects: true,
                       }) as string[]
                     ).map((feature: string, index: number) => (
@@ -380,7 +380,7 @@ export default function CorePrograms() {
                 </FeaturesList>
               </div>
               <LearnMoreButton endIcon={<ArrowForwardIcon />}>
-                {t("programs:core.learn_more")}
+                {t("programs.core.learn_more")}
               </LearnMoreButton>
             </ProgramContent>
           </HorizontalCard>
@@ -392,35 +392,35 @@ export default function CorePrograms() {
             <ProgramContent sx={{ order: { xs: 2, md: 1 } }}>
               <div>
                 <Badge bgcolor='rgba(150, 89, 149, 0.1)'>
-                  <BadgeText>{t("programs:core.program2.badge")}</BadgeText>
+                  <BadgeText>{t("programs.core.program2.badge")}</BadgeText>
                 </Badge>
-                <ProgramTitle>{t("programs:core.program2.title")}</ProgramTitle>
+                <ProgramTitle>{t("programs.core.program2.title")}</ProgramTitle>
                 <ProgramDescription>
-                  {t("programs:core.program2.description")}
+                  {t("programs.core.program2.description")}
                 </ProgramDescription>
                 <StatsContainer>
                   <StatItem>
                     <StatNumber color='#351c42'>1200+</StatNumber>
-                    <StatLabel>{t("programs:core.beneficiaries")}</StatLabel>
+                    <StatLabel>{t("programs.core.beneficiaries")}</StatLabel>
                   </StatItem>
                   <StatItem>
                     <StatNumber color='#2b2b2b'>15</StatNumber>
-                    <StatLabel>{t("programs:core.projects")}</StatLabel>
+                    <StatLabel>{t("programs.core.projects")}</StatLabel>
                   </StatItem>
                   <StatItem>
                     <StatNumber color='#2b2b2b'>High</StatNumber>
-                    <StatLabel>{t("programs:core.impact")}</StatLabel>
+                    <StatLabel>{t("programs.core.impact")}</StatLabel>
                   </StatItem>
                 </StatsContainer>
-                <FeaturesTitle>{t("programs:core.key_features")}</FeaturesTitle>
+                <FeaturesTitle>{t("programs.core.key_features")}</FeaturesTitle>
                 <FeaturesList>
                   {Array.isArray(
-                    t("programs:core.program2.features", {
+                    t("programs.core.program2.features", {
                       returnObjects: true,
                     })
                   ) &&
                     (
-                      t("programs:core.program2.features", {
+                      t("programs.core.program2.features", {
                         returnObjects: true,
                       }) as string[]
                     ).map((feature: string, index: number) => (
@@ -434,13 +434,13 @@ export default function CorePrograms() {
                 </FeaturesList>
               </div>
               <LearnMoreButton endIcon={<ArrowForwardIcon />}>
-                {t("programs:core.learn_more")}
+                {t("programs.core.learn_more")}
               </LearnMoreButton>
             </ProgramContent>
             <Box position='relative' sx={{ order: { xs: 1, md: 2 } }}>
               <ProgramImage
                 src={program2}
-                alt={t("programs:core.program2.image_alt")}
+                alt={t("programs.core.program2.image_alt")}
               />
               <IconBadge
                 bgcolor='white'
@@ -460,7 +460,7 @@ export default function CorePrograms() {
             <Box position='relative'>
               <VerticalCardImage
                 src={program3}
-                alt={t("programs:core.program3.image_alt")}
+                alt={t("programs.core.program3.image_alt")}
               />
               <Badge
                 bgcolor='#2b2b2b'
@@ -472,7 +472,7 @@ export default function CorePrograms() {
                 }}
               >
                 <BadgeText sx={{ color: "white" }}>
-                  {t("programs:core.program3.badge")}
+                  {t("programs.core.program3.badge")}
                 </BadgeText>
               </Badge>
               <IconBadge
@@ -485,33 +485,33 @@ export default function CorePrograms() {
             </Box>
             <VerticalCardContent>
               <VerticalCardTitle>
-                {t("programs:core.program3.title")}
+                {t("programs.core.program3.title")}
               </VerticalCardTitle>
               <VerticalCardDescription>
-                {t("programs:core.program3.description")}
+                {t("programs.core.program3.description")}
               </VerticalCardDescription>
               <VerticalStatsContainer>
                 <StatItem>
                   <VerticalStatNumber color='#00a77f'>3000+</VerticalStatNumber>
                   <VerticalStatLabel>
-                    {t("programs:core.beneficiaries")}
+                    {t("programs.core.beneficiaries")}
                   </VerticalStatLabel>
                 </StatItem>
                 <StatItem>
                   <VerticalStatNumber>30</VerticalStatNumber>
                   <VerticalStatLabel>
-                    {t("programs:core.projects")}
+                    {t("programs.core.projects")}
                   </VerticalStatLabel>
                 </StatItem>
                 <StatItem>
                   <VerticalStatNumber>Very High</VerticalStatNumber>
                   <VerticalStatLabel>
-                    {t("programs:core.impact")}
+                    {t("programs.core.impact")}
                   </VerticalStatLabel>
                 </StatItem>
               </VerticalStatsContainer>
               <VerticalLearnMoreButton endIcon={<ArrowForwardIcon />}>
-                {t("programs:core.learn_more")}
+                {t("programs.core.learn_more")}
               </VerticalLearnMoreButton>
             </VerticalCardContent>
           </VerticalCard>
@@ -521,7 +521,7 @@ export default function CorePrograms() {
             <Box position='relative'>
               <VerticalCardImage
                 src={program4}
-                alt={t("programs:core.program4.image_alt")}
+                alt={t("programs.core.program4.image_alt")}
               />
               <Badge
                 bgcolor='#004c91'
@@ -533,39 +533,39 @@ export default function CorePrograms() {
                 }}
               >
                 <BadgeText sx={{ color: "white" }}>
-                  {t("programs:core.program4.badge")}
+                  {t("programs.core.program4.badge")}
                 </BadgeText>
               </Badge>
             </Box>
             <VerticalCardContent>
               <VerticalCardTitle>
-                {t("programs:core.program4.title")}
+                {t("programs.core.program4.title")}
               </VerticalCardTitle>
               <VerticalCardDescription>
-                {t("programs:core.program4.description")}
+                {t("programs.core.program4.description")}
               </VerticalCardDescription>
               <VerticalStatsContainer>
                 <StatItem>
                   <VerticalStatNumber>2500+</VerticalStatNumber>
                   <VerticalStatLabel>
-                    {t("programs:core.beneficiaries")}
+                    {t("programs.core.beneficiaries")}
                   </VerticalStatLabel>
                 </StatItem>
                 <StatItem>
                   <VerticalStatNumber>20</VerticalStatNumber>
                   <VerticalStatLabel>
-                    {t("programs:core.projects")}
+                    {t("programs.core.projects")}
                   </VerticalStatLabel>
                 </StatItem>
                 <StatItem>
                   <VerticalStatNumber>High</VerticalStatNumber>
                   <VerticalStatLabel>
-                    {t("programs:core.impact")}
+                    {t("programs.core.impact")}
                   </VerticalStatLabel>
                 </StatItem>
               </VerticalStatsContainer>
               <VerticalLearnMoreButton endIcon={<ArrowForwardIcon />}>
-                {t("programs:core.learn_more")}
+                {t("programs.core.learn_more")}
               </VerticalLearnMoreButton>
             </VerticalCardContent>
           </VerticalCard>
@@ -575,7 +575,7 @@ export default function CorePrograms() {
             <Box position='relative'>
               <VerticalCardImage
                 src={program5}
-                alt={t("programs:core.program5.image_alt")}
+                alt={t("programs.core.program5.image_alt")}
               />
               <Badge
                 bgcolor='white'
@@ -587,7 +587,7 @@ export default function CorePrograms() {
                 }}
               >
                 <BadgeText sx={{ color: "#004c91" }}>
-                  {t("programs:core.program5.badge")}
+                  {t("programs.core.program5.badge")}
                 </BadgeText>
               </Badge>
               <IconBadge
@@ -600,33 +600,33 @@ export default function CorePrograms() {
             </Box>
             <VerticalCardContent>
               <VerticalCardTitle>
-                {t("programs:core.program5.title")}
+                {t("programs.core.program5.title")}
               </VerticalCardTitle>
               <VerticalCardDescription>
-                {t("programs:core.program5.description")}
+                {t("programs.core.program5.description")}
               </VerticalCardDescription>
               <VerticalStatsContainer>
                 <StatItem>
                   <VerticalStatNumber>4000+</VerticalStatNumber>
                   <VerticalStatLabel>
-                    {t("programs:core.beneficiaries")}
+                    {t("programs.core.beneficiaries")}
                   </VerticalStatLabel>
                 </StatItem>
                 <StatItem>
                   <VerticalStatNumber>18</VerticalStatNumber>
                   <VerticalStatLabel>
-                    {t("programs:core.projects")}
+                    {t("programs.core.projects")}
                   </VerticalStatLabel>
                 </StatItem>
                 <StatItem>
                   <VerticalStatNumber>Very High</VerticalStatNumber>
                   <VerticalStatLabel>
-                    {t("programs:core.impact")}
+                    {t("programs.core.impact")}
                   </VerticalStatLabel>
                 </StatItem>
               </VerticalStatsContainer>
               <VerticalLearnMoreButton endIcon={<ArrowForwardIcon />}>
-                {t("programs:core.learn_more")}
+                {t("programs.core.learn_more")}
               </VerticalLearnMoreButton>
             </VerticalCardContent>
           </VerticalCard>

--- a/src/components/programs/OurApproach.tsx
+++ b/src/components/programs/OurApproach.tsx
@@ -102,32 +102,32 @@ export default function OurApproach() {
     {
       icon: <AssessmentIcon />,
       number: "01",
-      title: t("programs:approach.assessment.title"),
-      description: t("programs:approach.assessment.description"),
+      title: t("programs.approach.assessment.title"),
+      description: t("programs.approach.assessment.description"),
       iconBg: "rgba(0, 76, 145, 0.1)",
       iconColor: "#004c91",
     },
     {
       icon: <DesignServicesIcon />,
       number: "02",
-      title: t("programs:approach.design.title"),
-      description: t("programs:approach.design.description"),
+      title: t("programs.approach.design.title"),
+      description: t("programs.approach.design.description"),
       iconBg: "rgba(0, 167, 127, 0.1)",
       iconColor: "#00a77f",
     },
     {
       icon: <BuildIcon />,
       number: "03",
-      title: t("programs:approach.implementation.title"),
-      description: t("programs:approach.implementation.description"),
+      title: t("programs.approach.implementation.title"),
+      description: t("programs.approach.implementation.description"),
       iconBg: "rgba(150, 85, 149, 0.1)",
       iconColor: "#965595",
     },
     {
       icon: <InsightsIcon />,
       number: "04",
-      title: t("programs:approach.evaluation.title"),
-      description: t("programs:approach.evaluation.description"),
+      title: t("programs.approach.evaluation.title"),
+      description: t("programs.approach.evaluation.description"),
       iconBg: "rgba(246, 212, 105, 0.1)",
       iconColor: "#2b2b2b",
     },
@@ -138,10 +138,10 @@ export default function OurApproach() {
       <Container maxWidth='xl'>
         <SectionHeader>
           <SectionTitle id='our-approach-title'>
-            {t("programs:approach.title")}
+            {t("programs.approach.title")}
           </SectionTitle>
           <SectionDescription>
-            {t("programs:approach.description")}
+            {t("programs.approach.description")}
           </SectionDescription>
         </SectionHeader>
         <ApproachGrid>

--- a/src/components/programs/ProgramStats.tsx
+++ b/src/components/programs/ProgramStats.tsx
@@ -72,7 +72,7 @@ export default function ProgramStats() {
     {
       icon: <GroupsIcon />,
       number: "15,000+",
-      label: t("programs:stats.lives_impacted"),
+      label: t("programs.stats.lives_impacted"),
       iconBg: "rgba(0, 76, 145, 0.1)",
       iconColor: "#004c91",
       numberColor: "#004c91",
@@ -80,7 +80,7 @@ export default function ProgramStats() {
     {
       icon: <CheckCircleIcon />,
       number: "5",
-      label: t("programs:stats.core_programs"),
+      label: t("programs.stats.core_programs"),
       iconBg: "#ffffff",
       iconColor: "#2b2b2b",
       numberColor: "#2b2b2b",
@@ -88,7 +88,7 @@ export default function ProgramStats() {
     {
       icon: <EmojiEventsIcon />,
       number: "108",
-      label: t("programs:stats.projects_delivered"),
+      label: t("programs.stats.projects_delivered"),
       iconBg: "#004c91",
       iconColor: "white",
       numberColor: "#2b2b2b",
@@ -96,7 +96,7 @@ export default function ProgramStats() {
     {
       icon: <TrendingUpIcon />,
       number: "95%",
-      label: t("programs:stats.success_rate"),
+      label: t("programs.stats.success_rate"),
       iconBg: "rgba(246, 212, 105, 0.1)",
       iconColor: "#004c91",
       numberColor: "#004c91",
@@ -110,7 +110,7 @@ export default function ProgramStats() {
           id='programs-stats-title'
           sx={{ position: "absolute", left: "-10000px" }}
         >
-          {t("programs:stats.section_title")}
+          {t("programs.stats.section_title")}
         </Typography>
         <StatsGrid>
           {stats.map((stat, index) => (

--- a/src/components/programs/ProgramsCTA.tsx
+++ b/src/components/programs/ProgramsCTA.tsx
@@ -105,21 +105,21 @@ export default function ProgramsCTA() {
       <GradientOverlay aria-hidden='true' />
       <Container maxWidth='xl'>
         <ContentContainer>
-          <CTATitle id='programs-cta-title'>{t("programs:cta.title")}</CTATitle>
-          <CTADescription>{t("programs:cta.description")}</CTADescription>
+          <CTATitle id='programs-cta-title'>{t("programs.cta.title")}</CTATitle>
+          <CTADescription>{t("programs.cta.description")}</CTADescription>
           <ButtonContainer>
             <PrimaryButton
               href='/get-involved'
               endIcon={<ArrowForwardIcon />}
-              aria-label={t("programs:cta.get_involved_button")}
+              aria-label={t("programs.cta.get_involved_button")}
             >
-              {t("programs:cta.get_involved_button")}
+              {t("programs.cta.get_involved_button")}
             </PrimaryButton>
             <SecondaryButton
               href='/contact'
-              aria-label={t("programs:cta.contact_button")}
+              aria-label={t("programs.cta.contact_button")}
             >
-              {t("programs:cta.contact_button")}
+              {t("programs.cta.contact_button")}
             </SecondaryButton>
           </ButtonContainer>
         </ContentContainer>

--- a/src/components/programs/ProgramsHero.tsx
+++ b/src/components/programs/ProgramsHero.tsx
@@ -130,25 +130,25 @@ export default function ProgramsHero() {
       <Container maxWidth='lg' sx={{ position: "relative", zIndex: 1 }}>
         <Box maxWidth='800px'>
           <Badge>
-            <BadgeText>{t("programs:hero.badge")}</BadgeText>
+            <BadgeText>{t("programs.hero.badge")}</BadgeText>
           </Badge>
           <Title id='programs-hero-title' variant='h1'>
-            {t("programs:hero.title")}
+            {t("programs.hero.title")}
           </Title>
-          <Description>{t("programs:hero.description")}</Description>
+          <Description>{t("programs.hero.description")}</Description>
           <CTAContainer>
             <PrimaryButton
               onClick={scrollToPrograms}
               endIcon={<ArrowForwardIcon />}
-              aria-label={t("programs:hero.explore_button")}
+              aria-label={t("programs.hero.explore_button")}
             >
-              {t("programs:hero.explore_button")}
+              {t("programs.hero.explore_button")}
             </PrimaryButton>
             <SecondaryButton
               href='/get-involved'
-              aria-label={t("programs:hero.get_involved_button")}
+              aria-label={t("programs.hero.get_involved_button")}
             >
-              {t("programs:hero.get_involved_button")}
+              {t("programs.hero.get_involved_button")}
             </SecondaryButton>
           </CTAContainer>
         </Box>

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -15,6 +15,8 @@ interface AuthContextType {
   logout: () => void;
   isAuthenticated: boolean;
   isAdmin: boolean;
+  isOwner: boolean;
+  isAdminOrOwner: boolean;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -49,10 +51,20 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
 
   const isAuthenticated = !!user;
   const isAdmin = user?.role === "ADMIN";
+  const isOwner = user?.role === "OWNER";
+  const isAdminOrOwner = isAdmin || isOwner;
 
   return (
     <AuthContext.Provider
-      value={{ user, login, logout, isAuthenticated, isAdmin }}
+      value={{
+        user,
+        login,
+        logout,
+        isAuthenticated,
+        isAdmin,
+        isOwner,
+        isAdminOrOwner,
+      }}
     >
       {children}
     </AuthContext.Provider>

--- a/src/views/Login.tsx
+++ b/src/views/Login.tsx
@@ -134,7 +134,17 @@ const Login: React.FC = () => {
 
       if (data.success && data.user) {
         login(data.user);
-        navigate("/");
+
+        // Route based on user role
+        if (data.user.role === "OWNER") {
+          navigate("/owner/dashboard");
+        } else if (data.user.role === "ADMIN") {
+          navigate("/admin/dashboard");
+        } else if (data.user.role === "MEMBER") {
+          navigate("/member/dashboard");
+        } else {
+          navigate("/");
+        }
       } else {
         setError(data.message || t("auth_error_login_failed"));
       }

--- a/src/views/OwnerDashboard.tsx
+++ b/src/views/OwnerDashboard.tsx
@@ -1,0 +1,614 @@
+import React, { useState, useEffect } from "react";
+import { styled } from "@mui/material/styles";
+import { usePageTitle } from "../hooks/usePageTitle";
+import {
+  Box,
+  Container,
+  Typography,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Tabs,
+  Tab,
+  CircularProgress,
+  Alert,
+  Chip,
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  Select,
+  MenuItem,
+  FormControl,
+  InputLabel,
+  IconButton,
+  Tooltip,
+} from "@mui/material";
+import DeleteIcon from "@mui/icons-material/Delete";
+import EditIcon from "@mui/icons-material/Edit";
+import PersonAddIcon from "@mui/icons-material/PersonAdd";
+import BlockIcon from "@mui/icons-material/Block";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import { useAuth } from "../contexts/AuthContext";
+import { useNavigate } from "react-router-dom";
+import ApiService from "../services/ApiService";
+import AdminDashboard from "./AdminDashboard";
+
+const PageContainer = styled(Box)({
+  minHeight: "100vh",
+  backgroundColor: "#f5f5f5",
+  padding: "40px 0",
+});
+
+const Title = styled("h1")({
+  fontSize: "36px",
+  fontWeight: 600,
+  color: "#004c91",
+  fontFamily: '"Roboto","Helvetica","Arial",sans-serif',
+  margin: 0,
+  marginBottom: "32px",
+});
+
+const StyledPaper = styled(Paper)({
+  padding: "24px",
+  borderRadius: "16px",
+  boxShadow: "0 2px 12px rgba(0,0,0,0.08)",
+});
+
+const StyledTableCell = styled(TableCell)({
+  fontWeight: 500,
+  backgroundColor: "#f8f9fa",
+  color: "#004c91",
+});
+
+const ActionButton = styled(Button)({
+  marginRight: "8px",
+  textTransform: "none",
+});
+
+interface User {
+  id: number;
+  username: string;
+  email: string;
+  fullName: string;
+  role: string;
+  enabled: boolean;
+  createdAt: string;
+}
+
+interface TabPanelProps {
+  children?: React.ReactNode;
+  index: number;
+  value: number;
+}
+
+function TabPanel(props: TabPanelProps) {
+  const { children, value, index, ...other } = props;
+  const isActive = value === index;
+
+  return (
+    <div
+      role='tabpanel'
+      hidden={!isActive}
+      id={`owner-tabpanel-${index}`}
+      aria-labelledby={`owner-tab-${index}`}
+      aria-hidden={!isActive}
+      {...other}
+    >
+      {isActive && <Box sx={{ pt: 3 }}>{children}</Box>}
+    </div>
+  );
+}
+
+const OwnerDashboard: React.FC = () => {
+  usePageTitle("page_titles.owner_dashboard");
+  const { user } = useAuth();
+  const navigate = useNavigate();
+  const [tabValue, setTabValue] = useState(0);
+  const [users, setUsers] = useState<User[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  // Dialog states
+  const [openCreateDialog, setOpenCreateDialog] = useState(false);
+  const [openEditDialog, setOpenEditDialog] = useState(false);
+  const [openDeleteDialog, setOpenDeleteDialog] = useState(false);
+  const [selectedUser, setSelectedUser] = useState<User | null>(null);
+
+  // Form states
+  const [formData, setFormData] = useState({
+    username: "",
+    email: "",
+    password: "",
+    fullName: "",
+    role: "MEMBER",
+  });
+
+  useEffect(() => {
+    if (user?.role !== "OWNER") {
+      navigate("/");
+      return;
+    }
+
+    if (tabValue === 0) {
+      fetchUsers();
+    }
+  }, [user, navigate, tabValue]);
+
+  const fetchUsers = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await ApiService.get("/api/users", {
+        headers: { Authorization: `Bearer ${user?.token}` },
+      });
+      setUsers(Array.isArray(response) ? response : []);
+    } catch (err: any) {
+      setError(err.message || "Failed to fetch users");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleCreateUser = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await ApiService.post("/api/users", formData, {
+        headers: { Authorization: `Bearer ${user?.token}` },
+      });
+
+      if (response.success) {
+        setSuccessMessage("User created successfully");
+        setOpenCreateDialog(false);
+        setFormData({
+          username: "",
+          email: "",
+          password: "",
+          fullName: "",
+          role: "MEMBER",
+        });
+        fetchUsers();
+        setTimeout(() => setSuccessMessage(null), 3000);
+      } else {
+        setError(response.error || "Failed to create user");
+      }
+    } catch (err: any) {
+      setError(err.message || "Failed to create user");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleUpdateRole = async (userId: number, newRole: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await ApiService.put(
+        `/api/users/${userId}/role`,
+        { role: newRole },
+        {
+          headers: { Authorization: `Bearer ${user?.token}` },
+        }
+      );
+
+      if (response.success) {
+        setSuccessMessage("User role updated successfully");
+        setOpenEditDialog(false);
+        setSelectedUser(null);
+        fetchUsers();
+        setTimeout(() => setSuccessMessage(null), 3000);
+      } else {
+        setError(response.error || "Failed to update user role");
+      }
+    } catch (err: any) {
+      setError(err.message || "Failed to update user role");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDeleteUser = async () => {
+    if (!selectedUser) return;
+
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await ApiService.delete(
+        `/api/users/${selectedUser.id}`,
+        {
+          headers: { Authorization: `Bearer ${user?.token}` },
+        }
+      );
+
+      if (response.success) {
+        setSuccessMessage("User deleted successfully");
+        setOpenDeleteDialog(false);
+        setSelectedUser(null);
+        fetchUsers();
+        setTimeout(() => setSuccessMessage(null), 3000);
+      } else {
+        setError(response.error || "Failed to delete user");
+      }
+    } catch (err: any) {
+      setError(err.message || "Failed to delete user");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleToggleStatus = async (userId: number) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await ApiService.put(
+        `/api/users/${userId}/toggle-status`,
+        {},
+        {
+          headers: { Authorization: `Bearer ${user?.token}` },
+        }
+      );
+
+      if (response.success) {
+        setSuccessMessage("User status updated successfully");
+        fetchUsers();
+        setTimeout(() => setSuccessMessage(null), 3000);
+      } else {
+        setError(response.error || "Failed to update user status");
+      }
+    } catch (err: any) {
+      setError(err.message || "Failed to update user status");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getRoleColor = (role: string) => {
+    switch (role) {
+      case "OWNER":
+        return "error";
+      case "ADMIN":
+        return "warning";
+      case "MEMBER":
+        return "success";
+      default:
+        return "default";
+    }
+  };
+
+  const handleTabChange = (_event: React.SyntheticEvent, newValue: number) => {
+    setTabValue(newValue);
+  };
+
+  return (
+    <PageContainer>
+      <Container maxWidth='lg'>
+        <Title>Owner Dashboard</Title>
+
+        {error && (
+          <Alert severity='error' sx={{ mb: 3 }} onClose={() => setError(null)}>
+            {error}
+          </Alert>
+        )}
+
+        {successMessage && (
+          <Alert
+            severity='success'
+            sx={{ mb: 3 }}
+            onClose={() => setSuccessMessage(null)}
+          >
+            {successMessage}
+          </Alert>
+        )}
+
+        <StyledPaper>
+          <Tabs
+            value={tabValue}
+            onChange={handleTabChange}
+            aria-label='Owner dashboard tabs'
+            sx={{ borderBottom: 1, borderColor: "divider" }}
+          >
+            <Tab
+              label='User Management'
+              id='owner-tab-0'
+              aria-controls='owner-tabpanel-0'
+            />
+            <Tab
+              label='Admin Features'
+              id='owner-tab-1'
+              aria-controls='owner-tabpanel-1'
+            />
+          </Tabs>
+
+          {/* User Management Tab */}
+          <TabPanel value={tabValue} index={0}>
+            <Box
+              sx={{
+                mb: 3,
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+              }}
+            >
+              <Typography variant='h6' component='h2'>
+                All Users
+              </Typography>
+              <Button
+                variant='contained'
+                color='primary'
+                startIcon={<PersonAddIcon />}
+                onClick={() => setOpenCreateDialog(true)}
+                aria-label='Add new user'
+              >
+                Add User
+              </Button>
+            </Box>
+
+            {loading ? (
+              <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
+                <CircularProgress />
+              </Box>
+            ) : (
+              <TableContainer>
+                <Table aria-label='Users table'>
+                  <TableHead>
+                    <TableRow>
+                      <StyledTableCell>Username</StyledTableCell>
+                      <StyledTableCell>Email</StyledTableCell>
+                      <StyledTableCell>Full Name</StyledTableCell>
+                      <StyledTableCell>Role</StyledTableCell>
+                      <StyledTableCell>Status</StyledTableCell>
+                      <StyledTableCell>Created</StyledTableCell>
+                      <StyledTableCell align='right'>Actions</StyledTableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {users.map((u) => (
+                      <TableRow key={u.id}>
+                        <TableCell>{u.username}</TableCell>
+                        <TableCell>{u.email}</TableCell>
+                        <TableCell>{u.fullName}</TableCell>
+                        <TableCell>
+                          <Chip
+                            label={u.role}
+                            color={getRoleColor(u.role)}
+                            size='small'
+                          />
+                        </TableCell>
+                        <TableCell>
+                          <Chip
+                            label={u.enabled ? "Active" : "Disabled"}
+                            color={u.enabled ? "success" : "default"}
+                            size='small'
+                          />
+                        </TableCell>
+                        <TableCell>
+                          {new Date(u.createdAt).toLocaleDateString()}
+                        </TableCell>
+                        <TableCell align='right'>
+                          <Tooltip title='Edit Role'>
+                            <IconButton
+                              size='small'
+                              onClick={() => {
+                                setSelectedUser(u);
+                                setOpenEditDialog(true);
+                              }}
+                              aria-label={`Edit ${u.username} role`}
+                            >
+                              <EditIcon fontSize='small' />
+                            </IconButton>
+                          </Tooltip>
+                          <Tooltip title={u.enabled ? "Disable" : "Enable"}>
+                            <IconButton
+                              size='small'
+                              onClick={() => handleToggleStatus(u.id)}
+                              aria-label={`${
+                                u.enabled ? "Disable" : "Enable"
+                              } ${u.username}`}
+                            >
+                              {u.enabled ? (
+                                <BlockIcon fontSize='small' />
+                              ) : (
+                                <CheckCircleIcon fontSize='small' />
+                              )}
+                            </IconButton>
+                          </Tooltip>
+                          <Tooltip title='Delete User'>
+                            <IconButton
+                              size='small'
+                              color='error'
+                              onClick={() => {
+                                setSelectedUser(u);
+                                setOpenDeleteDialog(true);
+                              }}
+                              aria-label={`Delete ${u.username}`}
+                            >
+                              <DeleteIcon fontSize='small' />
+                            </IconButton>
+                          </Tooltip>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </TableContainer>
+            )}
+          </TabPanel>
+
+          {/* Admin Features Tab - Reuse AdminDashboard */}
+          <TabPanel value={tabValue} index={1}>
+            <AdminDashboard />
+          </TabPanel>
+        </StyledPaper>
+
+        {/* Create User Dialog */}
+        <Dialog
+          open={openCreateDialog}
+          onClose={() => setOpenCreateDialog(false)}
+          maxWidth='sm'
+          fullWidth
+        >
+          <DialogTitle>Create New User</DialogTitle>
+          <DialogContent>
+            <TextField
+              autoFocus
+              margin='dense'
+              label='Username'
+              type='text'
+              fullWidth
+              value={formData.username}
+              onChange={(e) =>
+                setFormData({ ...formData, username: e.target.value })
+              }
+              required
+            />
+            <TextField
+              margin='dense'
+              label='Email'
+              type='email'
+              fullWidth
+              value={formData.email}
+              onChange={(e) =>
+                setFormData({ ...formData, email: e.target.value })
+              }
+              required
+            />
+            <TextField
+              margin='dense'
+              label='Password'
+              type='password'
+              fullWidth
+              value={formData.password}
+              onChange={(e) =>
+                setFormData({ ...formData, password: e.target.value })
+              }
+              required
+            />
+            <TextField
+              margin='dense'
+              label='Full Name'
+              type='text'
+              fullWidth
+              value={formData.fullName}
+              onChange={(e) =>
+                setFormData({ ...formData, fullName: e.target.value })
+              }
+            />
+            <FormControl fullWidth margin='dense'>
+              <InputLabel>Role</InputLabel>
+              <Select
+                value={formData.role}
+                label='Role'
+                onChange={(e) =>
+                  setFormData({ ...formData, role: e.target.value })
+                }
+              >
+                <MenuItem value='MEMBER'>Member</MenuItem>
+                <MenuItem value='ADMIN'>Admin</MenuItem>
+                <MenuItem value='OWNER'>Owner</MenuItem>
+              </Select>
+            </FormControl>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => setOpenCreateDialog(false)}>Cancel</Button>
+            <Button
+              onClick={handleCreateUser}
+              variant='contained'
+              color='primary'
+              disabled={loading}
+            >
+              Create
+            </Button>
+          </DialogActions>
+        </Dialog>
+
+        {/* Edit Role Dialog */}
+        <Dialog
+          open={openEditDialog}
+          onClose={() => setOpenEditDialog(false)}
+          maxWidth='sm'
+          fullWidth
+        >
+          <DialogTitle>Edit User Role</DialogTitle>
+          <DialogContent>
+            {selectedUser && (
+              <>
+                <Typography variant='body1' sx={{ mb: 2 }}>
+                  User: <strong>{selectedUser.username}</strong> (
+                  {selectedUser.email})
+                </Typography>
+                <FormControl fullWidth>
+                  <InputLabel>Role</InputLabel>
+                  <Select
+                    value={selectedUser.role}
+                    label='Role'
+                    onChange={(e) =>
+                      setSelectedUser({ ...selectedUser, role: e.target.value })
+                    }
+                  >
+                    <MenuItem value='MEMBER'>Member</MenuItem>
+                    <MenuItem value='ADMIN'>Admin</MenuItem>
+                    <MenuItem value='OWNER'>Owner</MenuItem>
+                  </Select>
+                </FormControl>
+              </>
+            )}
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => setOpenEditDialog(false)}>Cancel</Button>
+            <Button
+              onClick={() =>
+                selectedUser &&
+                handleUpdateRole(selectedUser.id, selectedUser.role)
+              }
+              variant='contained'
+              color='primary'
+              disabled={loading}
+            >
+              Update
+            </Button>
+          </DialogActions>
+        </Dialog>
+
+        {/* Delete User Dialog */}
+        <Dialog
+          open={openDeleteDialog}
+          onClose={() => setOpenDeleteDialog(false)}
+          maxWidth='sm'
+          fullWidth
+        >
+          <DialogTitle>Delete User</DialogTitle>
+          <DialogContent>
+            {selectedUser && (
+              <Typography>
+                Are you sure you want to delete user{" "}
+                <strong>{selectedUser.username}</strong> ({selectedUser.email})?
+                This action cannot be undone.
+              </Typography>
+            )}
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => setOpenDeleteDialog(false)}>Cancel</Button>
+            <Button
+              onClick={handleDeleteUser}
+              variant='contained'
+              color='error'
+              disabled={loading}
+            >
+              Delete
+            </Button>
+          </DialogActions>
+        </Dialog>
+      </Container>
+    </PageContainer>
+  );
+};
+
+export default OwnerDashboard;


### PR DESCRIPTION
- Add OWNER role to User entity enum (OWNER > ADMIN > MEMBER hierarchy)
- Create UserController with CRUD endpoints for user management (OWNER only)
- Create OwnerDashboard component with user management tab
- Update AuthService to default all new registrations to MEMBER role
- Add owner user initialization in DataInitializer
- Update AuthContext with isOwner and isAdminOrOwner helpers
- Add /owner/dashboard route and update Login to route by role
- Fix programs page translations (changed programs: to programs. namespace)
- Update PostgreSQL database constraint to include OWNER role
- Deploy backend with OWNER support to production server

Owner credentials: username 'owner' / password 'owner123' Backend API tested and working on production server